### PR TITLE
Fix redirect paths when session is not present

### DIFF
--- a/lib/sessionService.ts
+++ b/lib/sessionService.ts
@@ -166,7 +166,7 @@ export function withSession<
 
     if (!sessionJWT) {
       console.log("No session JWT found...");
-      return { redirect: { statusCode: 307, destination: `/login` } };
+      return { redirect: { statusCode: 307, destination: `/` } };
     }
 
     let sessionAuthRes;
@@ -177,7 +177,7 @@ export function withSession<
       });
     } catch (err) {
       console.error("Could not find member by session token", err);
-      return { redirect: { statusCode: 307, destination: `/login` } };
+      return { redirect: { statusCode: 307, destination: `/` } };
     }
 
     // Hide the session authentication result on the context

--- a/pages/[slug]/dashboard.tsx
+++ b/pages/[slug]/dashboard.tsx
@@ -45,7 +45,7 @@ export const getServerSideProps = withSession<Props, { slug: string }>(
     const org = await findByID(member.organization_id);
 
     if (org === null) {
-      return { redirect: { statusCode: 307, destination: `/login` } };
+      return { redirect: { statusCode: 307, destination: `/` } };
     }
 
     const [members, ssoConnections] = await Promise.all([

--- a/pages/[slug]/dashboard/oidc/[connection_id].tsx
+++ b/pages/[slug]/dashboard/oidc/[connection_id].tsx
@@ -167,7 +167,7 @@ export const getServerSideProps = withSession<
 
   const org = await findByID(member.organization_id);
   if (org === null) {
-    return { redirect: { statusCode: 307, destination: `/login` } };
+    return { redirect: { statusCode: 307, destination: `/` } };
   }
 
   const connection = await list(org.organization_id).then((res) => {

--- a/pages/[slug]/dashboard/saml/[connection_id].tsx
+++ b/pages/[slug]/dashboard/saml/[connection_id].tsx
@@ -131,7 +131,7 @@ export const getServerSideProps = withSession<
 
   const org = await findByID(member.organization_id);
   if (org === null) {
-    return { redirect: { statusCode: 307, destination: `/login` } };
+    return { redirect: { statusCode: 307, destination: `/` } };
   }
 
   const connection = await list(org.organization_id).then((res) =>

--- a/pages/[slug]/login.tsx
+++ b/pages/[slug]/login.tsx
@@ -70,7 +70,7 @@ const TenantedLogin = ({ org, domain }: Props) => {
             >
               Passwords
             </Link>
-            &nbsp;are also supported as part of Stych&apos;s Organization flow (not
+            &nbsp;are also supported as part of Stytch&apos;s Organization flow (not
             implemented as part of this example app).
           </p>
           <p>

--- a/pages/api/callback.ts
+++ b/pages/api/callback.ts
@@ -23,7 +23,7 @@ export async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
   } catch (error) {
     console.error("Could not authenticate in callback", error);
-    return res.redirect(307, "/login");
+    return res.redirect(307, "/");
   }
 }
 type ExchangeResult = { kind: "discovery" | "login"; token: string };

--- a/pages/api/discovery/[orgId].ts
+++ b/pages/api/discovery/[orgId].ts
@@ -39,7 +39,7 @@ export async function handler(req: NextApiRequest, res: NextApiResponse) {
   const discoverySessionData = getDiscoverySessionData(req, res);
   if (discoverySessionData.error) {
     console.log("No session tokens found...");
-    return { redirect: { statusCode: 307, destination: `/login` } };
+    return { redirect: { statusCode: 307, destination: `/` } };
   }
 
   const orgId = req.query.orgId;

--- a/pages/api/smsmfa/authenticate.ts
+++ b/pages/api/smsmfa/authenticate.ts
@@ -12,7 +12,7 @@ export async function handler(req: NextApiRequest, res: NextApiResponse) {
   const discoverySessionData = getDiscoverySessionData(req, res);
   if (discoverySessionData.error) {
     console.log("No session tokens found...");
-    return { redirect: { statusCode: 307, destination: `/login` } };
+    return { redirect: { statusCode: 307, destination: `/` } };
   }
 
   const { orgID, memberID, code } = req.body;

--- a/pages/orgswitcher.tsx
+++ b/pages/orgswitcher.tsx
@@ -80,7 +80,7 @@ export const getServerSideProps = withSession<Props>(async (context) => {
   );
   if (discoverySessionData.error) {
     console.log("No session tokens found...");
-    return { redirect: { statusCode: 307, destination: `/login` } };
+    return { redirect: { statusCode: 307, destination: `/` } };
   }
 
   const { discovered_organizations } =

--- a/pages/select-organization.tsx
+++ b/pages/select-organization.tsx
@@ -97,7 +97,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
   );
   if (discoverySessionData.error) {
     console.log("No session tokens found...");
-    return { redirect: { statusCode: 307, destination: `/login` } };
+    return { redirect: { statusCode: 307, destination: `/` } };
   }
 
   const { discovered_organizations } =


### PR DESCRIPTION
Updates the redirects when we can't find a session token from `/login` (the path before the recent app revamp) to `/`.